### PR TITLE
Improve support for newer compilers

### DIFF
--- a/src/device_matrix.hpp
+++ b/src/device_matrix.hpp
@@ -7,9 +7,11 @@
 #ifndef SD_DEVICE_MATRIX_HPP
 #define SD_DEVICE_MATRIX_HPP
 
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <type_traits>
+#include <utility>
 
 #include "thrust_wrapper.hpp"
 

--- a/src/multi_array.hpp
+++ b/src/multi_array.hpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #if defined(__HIPCC__) or defined(__CUDACC__)
 #define DEVICE_FUNC __host__ __device__

--- a/src/sd.hpp
+++ b/src/sd.hpp
@@ -1258,8 +1258,8 @@ struct thermalizer {
 
         // convert to uniform distribution
         uint64_t constexpr const max = std::numeric_limits<uint64_t>::max();
-        double constexpr const fac = 1. / (max + 1.);
-        T rnd = (rint[0] + 0.5) * fac;
+        double constexpr const fac = 1. / (static_cast<double>(max) + 1.);
+        T rnd = (static_cast<double>(rint[0]) + 0.5) * fac;
 #endif
         return std::sqrt(T{2.0}) * sqrt_kT_Dt * std::sqrt(T{12.0}) * (rnd - 0.5);
 

--- a/src/sd.hpp
+++ b/src/sd.hpp
@@ -3,6 +3,8 @@
 
 #include <vector>
 #include <cmath>
+#include <limits>
+#include <type_traits>
 
 #include "device_matrix.hpp"
 #include "multi_array.hpp"

--- a/src/thrust_wrapper.hpp
+++ b/src/thrust_wrapper.hpp
@@ -75,6 +75,7 @@ thrust::host_vector<T> operator+(thrust::host_vector<T> const &x,
 #else // Dependencies without THRUST
 #  include <algorithm>
 #  include <cassert>
+#  include <functional>
 #  include <iterator>
 #  include <tuple>
 #  include <vector>


### PR DESCRIPTION
Description of changes:
- fix compiler warning on Clang 10 and Clang 11
- avoid portability issues with implicit includes (more details in C++ Core Guidelines: [SF.10: Avoid dependencies on implicitly #included names](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf10-avoid-dependencies-on-implicitly-included-names)).
