### PR TITLE
Improve portability of size_t on recent compilers

### DIFF
--- a/include/stokesian_dynamics/sd_cpu.hpp
+++ b/include/stokesian_dynamics/sd_cpu.hpp
@@ -1,6 +1,7 @@
 #ifndef SD_CPU_HPP
 #define SD_CPU_HPP
 
+#include <cstddef>
 #include <vector>
 
 std::vector<double> sd_cpu(std::vector<double> const &x_host,

--- a/include/stokesian_dynamics/sd_gpu.hpp
+++ b/include/stokesian_dynamics/sd_gpu.hpp
@@ -1,6 +1,7 @@
 #ifndef SD_GPU_HPP
 #define SD_GPU_HPP
 
+#include <cstddef>
 #include <vector>
 
 std::vector<double> sd_gpu(std::vector<double> const &x_host,

--- a/src/device_matrix.hpp
+++ b/src/device_matrix.hpp
@@ -8,6 +8,7 @@
 #define SD_DEVICE_MATRIX_HPP
 
 #include <cmath>
+#include <cstddef>
 #include <iomanip>
 #include <limits>
 #include <type_traits>

--- a/src/multi_array.hpp
+++ b/src/multi_array.hpp
@@ -7,6 +7,7 @@
 #define SD_MULTI_ARRAY_HPP
 
 #include <cmath>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 #include <type_traits>

--- a/src/multi_array.hpp
+++ b/src/multi_array.hpp
@@ -61,7 +61,7 @@ struct all<> {
 
 // linearized_index
 
-template <size_t n, size_t... N>
+template <std::size_t n, std::size_t... N>
 struct linearized_index {
     template <typename... Idx>
     DEVICE_FUNC constexpr std::size_t operator()(Idx... idx) const noexcept {
@@ -72,7 +72,7 @@ struct linearized_index {
     }
 };
 
-template <size_t... N>
+template <std::size_t... N>
 struct linearized_index<0, N...> {
     template <typename... Idx>
     DEVICE_FUNC constexpr std::size_t operator()(Idx... idx) const noexcept {
@@ -83,7 +83,7 @@ struct linearized_index<0, N...> {
 
 // check_bounds
 
-template <size_t n, size_t... N>
+template <std::size_t n, std::size_t... N>
 struct check_bounds {
     template <typename... Idx>
     constexpr bool operator()(Idx... idx) const {
@@ -95,7 +95,7 @@ struct check_bounds {
     }
 };
 
-template <size_t... N>
+template <std::size_t... N>
 struct check_bounds<0, N...> {
     template <typename... Idx>
     constexpr bool operator()(Idx... idx) const {

--- a/src/sd.hpp
+++ b/src/sd.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <type_traits>
 

--- a/src/sd.hpp
+++ b/src/sd.hpp
@@ -667,7 +667,7 @@ struct lubrication {
     }
 
     // Computes the pair-wise lubrication interactions between particle pairs
-    DEVICE_FUNC void calc_lub(size_t pair_id, double dr,
+    DEVICE_FUNC void calc_lub(std::size_t pair_id, double dr,
                               multi_array<T, 3> const &d,
                               multi_array<T, 12, 12> &tabc,
                               multi_array<T, 12, 10> &tght,

--- a/src/sd_cpu.cpp
+++ b/src/sd_cpu.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <vector>
 
 #if THRUST_VERSION < 100908

--- a/src/sd_gpu.cu
+++ b/src/sd_gpu.cu
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <vector>
 
 #include "sd.hpp"


### PR DESCRIPTION
Follow-up to espressomd/espresso#4313

Description of changes:
* avoid portability issues with plain `size_t` by using `std::size_t`
* avoid portability issues with indirect includes of `<cstddef>` and `<stddef.h>`