### PR TITLE
Add support for recent CMake releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 # TODO: License header
+cmake_minimum_required(VERSION 3.20.2)
+cmake_policy(VERSION 3.20.2)
+
 project(StokesianDynamics LANGUAGES CXX)
 
 add_library(stokesian_dynamics INTERFACE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,13 @@ if(STOKESIAN_DYNAMICS_GPU)
 endif()
 
 if(STOKESIAN_DYNAMICS)
+  if(POLICY CMP0167)
+    # use BoostConfig.cmake shipped with Boost 1.70+ instead of the one in CMake
+    cmake_policy(SET CMP0167 NEW)
+  endif()
   find_package(BLAS REQUIRED)
   find_package(LAPACK REQUIRED)
-  find_package(Boost 1.65 REQUIRED)
+  find_package(Boost 1.71 REQUIRED)
   add_library(sd_cpu SHARED sd_cpu.cpp)
   add_library(StokesianDynamics::sd_cpu ALIAS sd_cpu)
   target_link_libraries(sd_cpu


### PR DESCRIPTION
Description of changes:
- add support for CMake 4.0rc and add a minimal version requirement
   - CMake 4.0 removed deprecated features introduced before CMake 3.5
   - CMake 4.0 warns about deprecated features introduced before CMake 3.10
   - CMake 3.11.0 is required to import targets with namespaces via FetchContent
   - CMake 3.20.2 improves CUDA support and Intel/nvcc compiler support
   - CMake policy CMP0167 is needed due to sunsetting of BoostConfig.cmake
- require Boost 1.71 or later